### PR TITLE
Fix the typo (btn-otlivne -> btn-outline)

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -654,8 +654,8 @@ gulp serve</textarea>
                     </ul>
                     <div>
                       <div class="btn-wrapper">
-                        <a href="#" class="btn btn-otline-dark align-items-center"><i class="icon-share"></i> Share</a>
-                        <a href="#" class="btn btn-otline-dark"><i class="icon-printer"></i> Print</a>
+                        <a href="#" class="btn btn-outline-dark align-items-center"><i class="icon-share"></i> Share</a>
+                        <a href="#" class="btn btn-outline-dark"><i class="icon-printer"></i> Print</a>
                         <a href="#" class="btn btn-primary text-white me-0"><i class="icon-download"></i> Export</a>
                       </div>
                     </div>

--- a/template/index.html
+++ b/template/index.html
@@ -487,8 +487,8 @@
                   </ul>
                   <div>
                     <div class="btn-wrapper">
-                      <a href="#" class="btn btn-otline-dark align-items-center"><i class="icon-share"></i> Share</a>
-                      <a href="#" class="btn btn-otline-dark"><i class="icon-printer"></i> Print</a>
+                      <a href="#" class="btn btn-outline-dark align-items-center"><i class="icon-share"></i> Share</a>
+                      <a href="#" class="btn btn-outline-dark"><i class="icon-printer"></i> Print</a>
                       <a href="#" class="btn btn-primary text-white me-0"><i class="icon-download"></i> Export</a>
                     </div>
                   </div>


### PR DESCRIPTION
Hi!

If I'm right, there's a typo I stumbled across.

`btn-otline` 

(I think `btn-tune-{color}` is right.)

This PR is for correcting this typo.

Please check it out! Thank you.